### PR TITLE
Collect only OK,(200,302) pages

### DIFF
--- a/lib/wayback_archiver/url_collector.rb
+++ b/lib/wayback_archiver/url_collector.rb
@@ -35,7 +35,7 @@ module WaybackArchiver
       options[:limit] = limit unless limit == -1
 
       Spidr.site(start_at_url, options) do |spider|
-        spider.every_page do |page|
+        spider.every_ok_page do |page|
           page_url = page.url.to_s
           urls << page_url
           WaybackArchiver.logger.debug "Found: #{page_url}"


### PR DESCRIPTION
Hello Mr. Buren, 
i propose another pull request, i hope you can approve.

The Archiver collects *every* page, means it tries to collect all 404 pages also. 
(Yes, i regret that i had not thoroughly tested the #24 pull request for every eventualities, but now i did)
The spider.every_ok_page ensures, the Archiver does not collect 404 pages. 
I have tested and it collects 200 (OK) and also 302 (Redirected) pages. 
As i use this very extensively, the 404 with invalid urls had stacked up for some sites like /typo3/.../typo3/.../typo3/ 
and so the 404 collection had slowed down the actual archiving task of this script 
or even render the archiving of a whole page unsuccessful.

Off Topic Enhancement 1
Also, i want to work on a command-line switch, that make the crawl archiving from off-domain content through this script possible to describe off-domain files as single url targets for this script and hand them to the Internet Archive. Because i have certain pages, that are only working cross-domain. What i want to create, is an archive or a collection of public broadcasting videos from some countrys. The html video page runs on one domain, while the videos are streamed from another domain.

Off Topic Enhancement 2
What i consider thoughtful would be to have a switch to spider the ressources of one page first, 
to ensure that the page runs before the following links are spidered. I will look in to the spidr documentation. 
I have opened an issue for wayback machine because the rewrite of the domains and the Same Origin Policy and CORB is yet still a problem for wayback machine. 
Also #15 would be the same approach for spidr.
Off Topic Enhancement 3
I have also the Idea to scrape the pages through chrome headless, like 
https://github.com/machinio/cuprite but nvm i make only suggestions.