### PR TITLE
avoid 429, ignore robots

### DIFF
--- a/lib/wayback_archiver.rb
+++ b/lib/wayback_archiver.rb
@@ -13,7 +13,7 @@ module WaybackArchiver
   USER_AGENT = "WaybackArchiver/#{WaybackArchiver::VERSION} (+#{INFO_LINK})".freeze
 
   # Default concurrency for archiving URLs
-  DEFAULT_CONCURRENCY = 1
+  DEFAULT_CONCURRENCY = 5
 
   # Maxmium number of links posted (-1 is no limit)
   DEFAULT_MAX_LIMIT = -1

--- a/lib/wayback_archiver.rb
+++ b/lib/wayback_archiver.rb
@@ -13,7 +13,7 @@ module WaybackArchiver
   USER_AGENT = "WaybackArchiver/#{WaybackArchiver::VERSION} (+#{INFO_LINK})".freeze
 
   # Default concurrency for archiving URLs
-  DEFAULT_CONCURRENCY = 5
+  DEFAULT_CONCURRENCY = 1
 
   # Maxmium number of links posted (-1 is no limit)
   DEFAULT_MAX_LIMIT = -1

--- a/lib/wayback_archiver/url_collector.rb
+++ b/lib/wayback_archiver/url_collector.rb
@@ -46,7 +46,7 @@ module WaybackArchiver
 
       Spidr.site(start_at_url, options) do |spider|
         spider.every_page do |page|
-          sleep(5)
+          sleep(2)
           page_url = page.url.to_s
           urls << page_url
           WaybackArchiver.logger.debug "Found: #{page_url}"

--- a/lib/wayback_archiver/url_collector.rb
+++ b/lib/wayback_archiver/url_collector.rb
@@ -29,13 +29,14 @@ module WaybackArchiver
       urls = []
       start_at_url = Request.build_uri(url).to_s
       options = {
-        robots: true,
+        robots: false,
         user_agent: WaybackArchiver.user_agent
       }
       options[:limit] = limit unless limit == -1
 
       Spidr.site(start_at_url, options) do |spider|
         spider.every_page do |page|
+          sleep(3)
           page_url = page.url.to_s
           urls << page_url
           WaybackArchiver.logger.debug "Found: #{page_url}"

--- a/lib/wayback_archiver/url_collector.rb
+++ b/lib/wayback_archiver/url_collector.rb
@@ -46,7 +46,7 @@ module WaybackArchiver
 
       Spidr.site(start_at_url, options) do |spider|
         spider.every_page do |page|
-          sleep(2)
+          sleep(5)
           page_url = page.url.to_s
           urls << page_url
           WaybackArchiver.logger.debug "Found: #{page_url}"

--- a/lib/wayback_archiver/url_collector.rb
+++ b/lib/wayback_archiver/url_collector.rb
@@ -36,7 +36,7 @@ module WaybackArchiver
 
       Spidr.site(start_at_url, options) do |spider|
         spider.every_page do |page|
-          sleep(3)
+          sleep(5)
           page_url = page.url.to_s
           urls << page_url
           WaybackArchiver.logger.debug "Found: #{page_url}"

--- a/wayback_archiver.gemspec
+++ b/wayback_archiver.gemspec
@@ -25,7 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'spidr',         '~> 0.6.0' # Crawl sites
   spec.add_runtime_dependency 'robots',        '~> 0.1' # Needed for spidr robots support
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0' # Concurrency primitivies
-
+  spec.add_runtime_dependency 'rexml',
+  
   spec.add_development_dependency 'bundler',   '~> 1.3'
   spec.add_development_dependency 'rake',      '~> 12.3'
   spec.add_development_dependency 'rspec',     '~> 3.1'

--- a/wayback_archiver.gemspec
+++ b/wayback_archiver.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'spidr',         '~> 0.6.0' # Crawl sites
   spec.add_runtime_dependency 'robots',        '~> 0.1' # Needed for spidr robots support
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0' # Concurrency primitivies
-  spec.add_runtime_dependency 'rexml',
+  spec.add_runtime_dependency 'rexml'
   
   spec.add_development_dependency 'bundler',   '~> 1.3'
   spec.add_development_dependency 'rake',      '~> 12.3'

--- a/wayback_archiver.gemspec
+++ b/wayback_archiver.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'redcarpet', '~> 3.2'
   spec.add_development_dependency 'webmock', '~> 3.0'
-  spec.add_development_dependency 'byebug', '~> 0'
+  spec.add_development_dependency 'byebug', '> 0'
 end

--- a/wayback_archiver.gemspec
+++ b/wayback_archiver.gemspec
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'redcarpet', '~> 3.2'
   spec.add_development_dependency 'webmock', '~> 3.0'
-  spec.add_development_dependency 'byebug', '> 0'
+  spec.add_development_dependency 'byebug', '~> 0'
 end


### PR DESCRIPTION
avoid 429, ignore robots:
lowerded concurrency to 1, sleep 5 seconds before next request.
the other patch is to ignore robots, as of these:
https://blog.archive.org/2017/04/17/robots-txt-meant-for-search-engines-dont-work-well-for-web-archives/