### PR TITLE
Set default concurrency to 1, due to harsher rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ require 'wayback_archiver'
 Configuration (the below values are the defaults)
 
 ```ruby
-WaybackArchiver.concurrency = 5
+WaybackArchiver.concurrency = 1
 WaybackArchiver.user_agent = WaybackArchiver::USER_AGENT
 WaybackArchiver.logger = Logger.new(STDOUT)
 WaybackArchiver.max_limit = -1 # unlimited

--- a/bin/wayback_archiver
+++ b/bin/wayback_archiver
@@ -35,7 +35,7 @@ optparse = OptionParser.new do |parser|
     hosts = value.map { |v| Regexp.new(v) } if value
   end
 
-  parser.on('--concurrency=5', Integer, 'Concurrency') do |value|
+  parser.on('--concurrency=1', Integer, 'Concurrency') do |value|
     concurrency = value
   end
 

--- a/lib/wayback_archiver.rb
+++ b/lib/wayback_archiver.rb
@@ -13,7 +13,7 @@ module WaybackArchiver
   USER_AGENT = "WaybackArchiver/#{WaybackArchiver::VERSION} (+#{INFO_LINK})".freeze
 
   # Default concurrency for archiving URLs
-  DEFAULT_CONCURRENCY = 5
+  DEFAULT_CONCURRENCY = 1
 
   # Maxmium number of links posted (-1 is no limit)
   DEFAULT_MAX_LIMIT = -1
@@ -72,7 +72,7 @@ module WaybackArchiver
   # @param [String] source (must be a valid URL).
   # @param concurrency [Integer]
   # @example Auto archive example.com
-  #    WaybackArchiver.auto('example.com') # Default concurrency is 5
+  #    WaybackArchiver.auto('example.com') # Default concurrency is 1
   # @example Auto archive example.com with low concurrency
   #    WaybackArchiver.auto('example.com', concurrency: 1)
   # @example Auto archive example.com and archive max 100 URLs
@@ -91,7 +91,7 @@ module WaybackArchiver
   # @param [Array<String, Regexp>] hosts to crawl
   # @param concurrency [Integer]
   # @example Crawl example.com and send all URLs of the same domain
-  #    WaybackArchiver.crawl('example.com') # Default concurrency is 5
+  #    WaybackArchiver.crawl('example.com') # Default concurrency is 1
   # @example Crawl example.com and send all URLs of the same domain with low concurrency
   #    WaybackArchiver.crawl('example.com', concurrency: 1)
   # @example Crawl example.com and archive max 100 URLs
@@ -114,7 +114,7 @@ module WaybackArchiver
   # @param [String] url to the sitemap.
   # @param concurrency [Integer]
   # @example Get example.com sitemap and archive all found URLs
-  #    WaybackArchiver.sitemap('example.com/sitemap.xml') # Default concurrency is 5
+  #    WaybackArchiver.sitemap('example.com/sitemap.xml') # Default concurrency is 1
   # @example Get example.com sitemap and archive all found URLs with low concurrency
   #    WaybackArchiver.sitemap('example.com/sitemap.xml', concurrency: 1)
   # @example Get example.com sitemap archive max 100 URLs

--- a/lib/wayback_archiver/archive.rb
+++ b/lib/wayback_archiver/archive.rb
@@ -9,7 +9,7 @@ module WaybackArchiver
     # Send URLs to Wayback Machine.
     # @return [Array<ArchiveResult>] with sent URLs.
     # @param [Array<String>] urls to send to the Wayback Machine.
-    # @param concurrency [Integer] the default is 5
+    # @param concurrency [Integer] the default is 1
     # @yield [archive_result] If a block is given, each result will be yielded
     # @yieldparam [ArchiveResult] archive_result
     # @example Archive urls, asynchronously
@@ -54,7 +54,7 @@ module WaybackArchiver
     # Send URLs to Wayback Machine by crawling the site.
     # @return [Array<ArchiveResult>] with URLs sent to the Wayback Machine.
     # @param [String] source for URL to crawl.
-    # @param concurrency [Integer] the default is 5
+    # @param concurrency [Integer] the default is 1
     # @param [Array<String, Regexp>] hosts to crawl
     # @yield [archive_result] If a block is given, each result will be yielded
     # @yieldparam [ArchiveResult] archive_result


### PR DESCRIPTION
Doesn't fix the problem, just makes it (slightly) less frequent.