### PR TITLE
Update Spidr gem constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,6 @@ Use your own adapter for posting found URLs
 WaybackArchiver.adapter = ->(url) { puts url } # whatever that responds to #call
 ```
 
-:information_source: This gem uses the `spidr` gem that has a bug in the version that is pushed to RubyGems, it's fixed in the `master` branch. Simply add `gem 'spidr', github: 'postmodern/spidr'` to your `Gemfile` to use the fixed version. See [#25](https://github.com/buren/wayback_archiver/issues/25) for details.
-
 ## CLI
 
 __Usage__:

--- a/wayback_archiver.gemspec
+++ b/wayback_archiver.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_runtime_dependency 'spidr',         '~> 0.6.0' # Crawl sites
+  spec.add_runtime_dependency 'spidr',         '~> 0.6.1' # Crawl sites
   spec.add_runtime_dependency 'robots',        '~> 0.1' # Needed for spidr robots support
   spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0' # Concurrency primitivies
 


### PR DESCRIPTION
It appears as though the Spidr gem issue referenced in the `README` and in #25 was resolved in v0.6.1 of that dependency. See [this comment](https://github.com/postmodern/spidr/issues/66#issuecomment-546204337) on the Spidr gem's repo:

> **Finally** fixed in 0.6.1.

This PR updates the constraint in `wayback_archiver.gemspec` and removes the note from the `README`.

Thanks for considering this PR and for the really useful gem!