### PR TITLE
byebug depedency version

### DIFF
--- a/wayback_archiver.gemspec
+++ b/wayback_archiver.gemspec
@@ -35,5 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'coveralls', '~> 0.8'
   spec.add_development_dependency 'redcarpet', '~> 3.2'
   spec.add_development_dependency 'webmock', '~> 3.0'
-  spec.add_development_dependency 'byebug', '> 0'
+  spec.add_development_dependency 'byebug', '~> 11.1.3'
 end


### PR DESCRIPTION
byebug without dependecy or "> 0" causes #49 
this fixes #49, updates byebug dependency version to 11.1.3