### PR TITLE
fix 429, limit to 5 requests per minute

### DIFF
--- a/lib/wayback_archiver/archive.rb
+++ b/lib/wayback_archiver/archive.rb
@@ -38,6 +38,7 @@ module WaybackArchiver
 
       urls_queue.each do |url|
         pool.post do
+          sleep(12)
           result = post_url(url)
           yield(result) if block_given?
           posted_urls << result unless result.errored?


### PR DESCRIPTION
wayback machine seems to have lowered the rate again.  always was hitting 429 after 1 minute.
resolution was to limit requests to 5 per minute
works for me, no more 429's.