### PR TITLE
Ruby 3 fixes and local robots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.1
-  - 2.5.0
-  - 2.6.0
-  - 2.7.0
+  - 3.0.0
+  - 3.1.0
+  - 3.2.0
+  - 3.3.0
 before_install: gem install bundler

--- a/lib/robots.rb
+++ b/lib/robots.rb
@@ -1,0 +1,162 @@
+#
+#  Copyright (c) 2008 Kyle Maxwell, contributors
+#
+#  Permission is hereby granted, free of charge, to any person
+#  obtaining a copy of this software and associated documentation
+#  files (the "Software"), to deal in the Software without
+#  restriction, including without limitation the rights to use,
+#  copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the
+#  Software is furnished to do so, subject to the following
+#  conditions:
+#
+#  The above copyright notice and this permission notice shall be
+#  included in all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#  OTHER DEALINGS IN THE SOFTWARE.
+#
+
+require "open-uri"
+require "uri"
+require "rubygems"
+require "timeout"
+
+class Robots
+  
+  DEFAULT_TIMEOUT = 3
+  
+  class ParsedRobots
+    
+    def initialize(uri, user_agent)
+      @last_accessed = Time.at(1)
+      
+      io = Robots.get_robots_txt(uri, user_agent)
+      
+      if !io || io.content_type != "text/plain" || io.status != ["200", "OK"]
+        io = StringIO.new("User-agent: *\nAllow: /\n")
+      end
+
+      @other = {}
+      @disallows = {}
+      @allows = {}
+      @delays = {} # added delays to make it work
+      agent = /.*/
+      io.each do |line|
+        next if line =~ /^\s*(#.*|$)/
+        arr = line.split(":")
+        key = arr.shift
+        value = arr.join(":").strip
+        value.strip!
+        case key
+        when "User-agent"
+          agent = to_regex(value)
+        when "Allow"
+          @allows[agent] ||= []
+          @allows[agent] << to_regex(value)
+        when "Disallow"
+          @disallows[agent] ||= []
+          @disallows[agent] << to_regex(value)
+        when "Crawl-delay"
+          @delays[agent] = value.to_i
+        else
+          @other[key] ||= []
+          @other[key] << value
+        end
+      end
+      
+      @parsed = true
+    end
+    
+    def allowed?(uri, user_agent)
+      return true unless @parsed
+      allowed = true
+      path = uri.request_uri
+      
+      @disallows.each do |key, value|
+        if user_agent =~ key
+          value.each do |rule|
+            if path =~ rule
+              allowed = false
+            end
+          end
+        end
+      end
+      
+      @allows.each do |key, value|
+        unless allowed      
+          if user_agent =~ key
+            value.each do |rule|
+              if path =~ rule
+                allowed = true
+              end
+            end
+          end
+        end
+      end
+      
+      if allowed && @delays[user_agent]
+        sleep @delays[user_agent] - (Time.now - @last_accessed)
+        @last_accessed = Time.now
+      end
+      
+      return allowed
+    end
+    
+    def other_values
+      @other
+    end
+    
+  protected
+    
+    def to_regex(pattern)
+      return /should-not-match-anything-123456789/ if pattern.strip.empty?
+      pattern = Regexp.escape(pattern)
+      pattern.gsub!(Regexp.escape("*"), ".*")
+      Regexp.compile("^#{pattern}")
+    end
+  end
+  
+  def self.get_robots_txt(uri, user_agent)
+    begin
+      Timeout::timeout(Robots.timeout) do
+        io = URI.join(uri.to_s, "/robots.txt").open("User-Agent" => user_agent) rescue nil
+      end 
+    rescue Timeout::Error
+      STDERR.puts "robots.txt request timed out"
+    end
+  end
+  
+  def self.timeout=(t)
+    @timeout = t
+  end
+  
+  def self.timeout
+    @timeout || DEFAULT_TIMEOUT
+  end
+  
+  def initialize(user_agent)
+    @user_agent = user_agent
+    @parsed = {}
+  end
+  
+  def allowed?(uri)
+    uri = URI.parse(uri.to_s) unless uri.is_a?(URI)
+    host = uri.host
+    @parsed[host] ||= ParsedRobots.new(uri, @user_agent)
+    @parsed[host].allowed?(uri, @user_agent)
+  end
+  
+  def other_values(uri)
+    uri = URI.parse(uri.to_s) unless uri.is_a?(URI)
+    host = uri.host
+    @parsed[host] ||= ParsedRobots.new(uri, @user_agent)
+    @parsed[host].other_values
+  end
+end

--- a/lib/wayback_archiver/url_collector.rb
+++ b/lib/wayback_archiver/url_collector.rb
@@ -44,7 +44,7 @@ module WaybackArchiver
       }
       options[:limit] = limit unless limit == -1
 
-      Spidr.site(start_at_url, options) do |spider|
+      Spidr.site(start_at_url, **options) do |spider|
         spider.every_page do |page|
           page_url = page.url.to_s
           urls << page_url

--- a/spec/wayback_archiver/request_spec.rb
+++ b/spec/wayback_archiver/request_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe WaybackArchiver::Request do
 
   describe '::build_redirect_uri' do
     it 'raises InvalidRedirectError if no location header is found' do
-      response = Struct.new(:header).new(location: nil)
+      response = Struct.new(:header).new({ location: nil })
       redirect_error = WaybackArchiver::Request::InvalidRedirectError
 
       expect do
@@ -128,7 +128,7 @@ RSpec.describe WaybackArchiver::Request do
 
     it 'adds base URI if location header is relative' do
       base_uri = 'http://example.com'
-      response = Struct.new(:header).new('location' => '/path')
+      response = Struct.new(:header).new({ 'location' => '/path' })
       result = described_class.build_redirect_uri(base_uri, response)
 
       expect(result).to eq(URI.parse('http://example.com/path'))
@@ -136,7 +136,7 @@ RSpec.describe WaybackArchiver::Request do
 
     it 'returns location header' do
       base_uri = 'http://example.com'
-      response = Struct.new(:header).new('location' => 'https://example.com/path')
+      response = Struct.new(:header).new({ 'location' => 'https://example.com/path' })
       result = described_class.build_redirect_uri(base_uri, response)
 
       expect(result).to eq(URI.parse('https://example.com/path'))

--- a/wayback_archiver.gemspec
+++ b/wayback_archiver.gemspec
@@ -22,10 +22,9 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_runtime_dependency 'spidr',         '~> 0.6.1' # Crawl sites
-  spec.add_runtime_dependency 'robots',        '< 0.10.1' # Needed for spidr robots support
-  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.0' # Concurrency primitivies
-  spec.add_runtime_dependency 'rexml',         '~> 3.2.5'
+  spec.add_runtime_dependency 'spidr',         '~> 0.7.1' # Crawl sites
+  spec.add_runtime_dependency 'concurrent-ruby', '~> 1.3' # Concurrency primitivies
+  spec.add_runtime_dependency 'rexml',         '~> 3.3.9'
 
   spec.add_development_dependency 'bundler',   '~> 2.1'
   spec.add_development_dependency 'rake',      '~> 12.3'


### PR DESCRIPTION
- Replace external gem `robots` for local copy in `lib/robots.rb`
- Ruby 3.0 fixes
- Update dependencies `rexml`, `spidr` and `concurrent-ruby`

Closes #51